### PR TITLE
Implement core detection engine with 19 automation detectors and scoring

### DIFF
--- a/packages/bot-detection/src/__tests__/detectors.test.ts
+++ b/packages/bot-detection/src/__tests__/detectors.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { State } from '../types'
+import type { CollectorDict } from '../types'
+import { DetectorRegistry } from '../detectors/registry'
+import { score } from '../detectors/scoring'
+import { BotKind } from '../detectors/types'
+import type { Detector, Signal } from '../detectors/types'
+import { automationDetectors } from '../detectors/automation'
+import webdriverDetector from '../detectors/automation/webdriver'
+import userAgentDetector from '../detectors/automation/user_agent'
+import evalLengthDetector from '../detectors/automation/eval_length'
+import pluginsInconsistencyDetector from '../detectors/automation/plugins_inconsistency'
+import languagesInconsistencyDetector from '../detectors/automation/languages_inconsistency'
+import webglDetector from '../detectors/automation/webgl'
+import windowSizeDetector from '../detectors/automation/window_size'
+import distinctivePropertiesDetector from '../detectors/automation/distinctive_properties'
+import documentElementKeysDetector from '../detectors/automation/document_element_keys'
+import functionBindDetector from '../detectors/automation/function_bind'
+import productSubDetector from '../detectors/automation/product_sub'
+import appVersionDetector from '../detectors/automation/app_version'
+import rttDetector from '../detectors/automation/rtt'
+
+function makeCollectorDict(overrides: Partial<Record<string, unknown>> = {}): CollectorDict {
+  const defaults: Record<string, unknown> = {
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0 Safari/537.36',
+    platform: 'Win32',
+    language: [['en-US'], ['en-US', 'en']],
+    timezone: { timezone: 'America/New_York', locale: 'en-US' },
+    webDriver: false,
+    webGl: { vendor: 'Google Inc. (NVIDIA)', renderer: 'ANGLE (NVIDIA GeForce GTX 1080)' },
+    documentFocus: true,
+    scrollBehavior: [],
+    mouseBehavior: [],
+    clickBehavior: [],
+    dimension: { width: 1920, height: 1080 },
+    plugins: 5,
+  }
+
+  const merged = { ...defaults, ...overrides }
+  const result: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(merged)) {
+    if (value !== null && typeof value === 'object' && 'state' in (value as Record<string, unknown>)) {
+      result[key] = value
+    } else {
+      result[key] = { state: State.Success, value }
+    }
+  }
+
+  return result as unknown as CollectorDict
+}
+
+describe('DetectorRegistry', () => {
+  it('registers and runs detectors', () => {
+    const registry = new DetectorRegistry()
+    const mockDetector: Detector = {
+      name: 'test',
+      category: 'automation',
+      detect: () => ({ detected: false, score: 0, reason: 'test: ok' }),
+    }
+    registry.register(mockDetector)
+    expect(registry.getDetectors()).toHaveLength(1)
+
+    const signals = registry.run(makeCollectorDict())
+    expect(signals).toHaveLength(1)
+    expect(signals[0]!.reason).toBe('test: ok')
+  })
+
+  it('catches errors from detectors', () => {
+    const registry = new DetectorRegistry()
+    const throwingDetector: Detector = {
+      name: 'broken',
+      category: 'automation',
+      detect: () => { throw new Error('boom') },
+    }
+    registry.register(throwingDetector)
+
+    const signals = registry.run(makeCollectorDict())
+    expect(signals).toHaveLength(1)
+    expect(signals[0]!.detected).toBe(false)
+    expect(signals[0]!.reason).toContain('threw an error')
+  })
+
+  it('registerAll adds multiple detectors', () => {
+    const registry = new DetectorRegistry()
+    registry.registerAll(automationDetectors)
+    expect(registry.getDetectors().length).toBe(automationDetectors.length)
+  })
+})
+
+describe('Automation Detectors', () => {
+  describe('webdriver', () => {
+    it('detects webdriver=true', () => {
+      const data = makeCollectorDict({ webDriver: true })
+      const signal = webdriverDetector.detect(data)
+      expect(signal.detected).toBe(true)
+      expect(signal.score).toBe(1.0)
+    })
+
+    it('passes when webdriver=false', () => {
+      const data = makeCollectorDict({ webDriver: false })
+      const signal = webdriverDetector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+
+    it('handles unavailable collector', () => {
+      const data = makeCollectorDict({
+        webDriver: { state: State.Undefined, error: 'missing' } as unknown,
+      })
+      const signal = webdriverDetector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+  })
+
+  describe('userAgent', () => {
+    it('detects HeadlessChrome', () => {
+      const data = makeCollectorDict({ userAgent: 'Mozilla/5.0 HeadlessChrome/120.0.0.0' })
+      const signal = userAgentDetector.detect(data)
+      expect(signal.detected).toBe(true)
+      expect(signal.botKind).toBe(BotKind.HeadlessChrome)
+    })
+
+    it('detects PhantomJS', () => {
+      const data = makeCollectorDict({ userAgent: 'Mozilla/5.0 PhantomJS/2.1.1' })
+      const signal = userAgentDetector.detect(data)
+      expect(signal.detected).toBe(true)
+      expect(signal.botKind).toBe(BotKind.PhantomJS)
+    })
+
+    it('passes normal Chrome UA', () => {
+      const data = makeCollectorDict()
+      const signal = userAgentDetector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+  })
+
+  describe('evalLength', () => {
+    it('does not flag standard eval length', () => {
+      const signal = evalLengthDetector.detect(makeCollectorDict())
+      expect(signal.detected).toBe(false)
+    })
+  })
+
+  describe('pluginsInconsistency', () => {
+    it('detects Chrome with 0 plugins', () => {
+      const data = makeCollectorDict({
+        userAgent: 'Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36',
+        plugins: 0,
+      })
+      const signal = pluginsInconsistencyDetector.detect(data)
+      expect(signal.detected).toBe(true)
+    })
+
+    it('passes Chrome with plugins', () => {
+      const data = makeCollectorDict({
+        userAgent: 'Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36',
+        plugins: 5,
+      })
+      const signal = pluginsInconsistencyDetector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+
+    it('passes Android Chrome with 0 plugins', () => {
+      const data = makeCollectorDict({
+        userAgent: 'Mozilla/5.0 (Linux; Android 13) Chrome/120.0.0.0',
+        plugins: 0,
+      })
+      const signal = pluginsInconsistencyDetector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+  })
+
+  describe('languagesInconsistency', () => {
+    it('detects empty languages', () => {
+      const data = makeCollectorDict({ language: [[], []] })
+      const signal = languagesInconsistencyDetector.detect(data)
+      expect(signal.detected).toBe(true)
+    })
+
+    it('passes with languages present', () => {
+      const data = makeCollectorDict()
+      const signal = languagesInconsistencyDetector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+  })
+
+  describe('webgl', () => {
+    it('detects SwiftShader renderer', () => {
+      const data = makeCollectorDict({
+        webGl: { vendor: 'Google Inc.', renderer: 'Google SwiftShader' },
+      })
+      const signal = webglDetector.detect(data)
+      expect(signal.detected).toBe(true)
+      expect(signal.reason).toContain('SwiftShader')
+    })
+
+    it('detects llvmpipe renderer', () => {
+      const data = makeCollectorDict({
+        webGl: { vendor: 'Mesa', renderer: 'llvmpipe (LLVM 12.0.0)' },
+      })
+      const signal = webglDetector.detect(data)
+      expect(signal.detected).toBe(true)
+    })
+
+    it('passes normal GPU', () => {
+      const data = makeCollectorDict()
+      const signal = webglDetector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+  })
+
+  describe('windowSize', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'outerWidth', { value: 1920, writable: true, configurable: true })
+      Object.defineProperty(window, 'outerHeight', { value: 1080, writable: true, configurable: true })
+    })
+
+    it('detects 0x0 outer dimensions', () => {
+      Object.defineProperty(window, 'outerWidth', { value: 0, writable: true, configurable: true })
+      Object.defineProperty(window, 'outerHeight', { value: 0, writable: true, configurable: true })
+      const data = makeCollectorDict({ documentFocus: true })
+      const signal = windowSizeDetector.detect(data)
+      expect(signal.detected).toBe(true)
+    })
+
+    it('skips when document not focused', () => {
+      const data = makeCollectorDict({ documentFocus: false })
+      const signal = windowSizeDetector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+
+    it('passes normal dimensions', () => {
+      const data = makeCollectorDict({ documentFocus: true })
+      const signal = windowSizeDetector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+  })
+
+  describe('distinctiveProperties', () => {
+    afterEach(() => {
+      // Clean up any properties we may have added
+      for (const prop of ['__nightmare', '__playwright', 'callPhantom', '_phantom', 'callSelenium']) {
+        delete (window as unknown as Record<string, unknown>)[prop]
+      }
+    })
+
+    it('detects __nightmare', () => {
+      (window as unknown as Record<string, unknown>).__nightmare = {}
+      const signal = distinctivePropertiesDetector.detect(makeCollectorDict())
+      expect(signal.detected).toBe(true)
+      expect(signal.botKind).toBe(BotKind.Nightmare)
+    })
+
+    it('detects __playwright', () => {
+      (window as unknown as Record<string, unknown>).__playwright = {}
+      const signal = distinctivePropertiesDetector.detect(makeCollectorDict())
+      expect(signal.detected).toBe(true)
+      expect(signal.botKind).toBe(BotKind.Playwright)
+    })
+
+    it('passes clean window', () => {
+      const signal = distinctivePropertiesDetector.detect(makeCollectorDict())
+      expect(signal.detected).toBe(false)
+    })
+  })
+
+  describe('documentElementKeys', () => {
+    it('passes clean document element', () => {
+      const signal = documentElementKeysDetector.detect(makeCollectorDict())
+      expect(signal.detected).toBe(false)
+    })
+  })
+
+  describe('functionBind', () => {
+    it('passes when bind exists', () => {
+      const signal = functionBindDetector.detect(makeCollectorDict())
+      expect(signal.detected).toBe(false)
+    })
+  })
+
+  describe('productSub', () => {
+    beforeEach(() => {
+      Object.defineProperty(navigator, 'productSub', {
+        value: '20030107',
+        writable: true,
+        configurable: true,
+      })
+    })
+
+    it('passes with correct productSub', () => {
+      const data = makeCollectorDict({
+        userAgent: 'Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36',
+      })
+      const signal = productSubDetector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+
+    it('detects wrong productSub for Chrome', () => {
+      Object.defineProperty(navigator, 'productSub', {
+        value: '20100101',
+        writable: true,
+        configurable: true,
+      })
+      const data = makeCollectorDict({
+        userAgent: 'Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36',
+      })
+      const signal = productSubDetector.detect(data)
+      expect(signal.detected).toBe(true)
+    })
+  })
+
+  describe('appVersion', () => {
+    it('detects HeadlessChrome in appVersion', () => {
+      Object.defineProperty(navigator, 'appVersion', {
+        value: '5.0 (X11; Linux) HeadlessChrome/120.0.0.0',
+        writable: true,
+        configurable: true,
+      })
+      const signal = appVersionDetector.detect(makeCollectorDict())
+      expect(signal.detected).toBe(true)
+    })
+  })
+
+  describe('rtt', () => {
+    it('detects rtt=0 on non-Android', () => {
+      Object.defineProperty(navigator, 'connection', {
+        value: { rtt: 0 },
+        writable: true,
+        configurable: true,
+      })
+      const data = makeCollectorDict({
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64) Chrome/120.0.0.0',
+      })
+      const signal = rttDetector.detect(data)
+      expect(signal.detected).toBe(true)
+    })
+
+    it('passes rtt=0 on Android', () => {
+      Object.defineProperty(navigator, 'connection', {
+        value: { rtt: 0 },
+        writable: true,
+        configurable: true,
+      })
+      const data = makeCollectorDict({
+        userAgent: 'Mozilla/5.0 (Linux; Android 13) Chrome/120.0.0.0',
+      })
+      const signal = rttDetector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+  })
+})
+
+describe('Scoring Engine', () => {
+  it('returns not-bot for clean signals', () => {
+    const signals: Signal[] = [
+      { detected: false, score: 0, reason: 'webdriver: not detected' },
+      { detected: false, score: 0, reason: 'userAgent: no bot patterns' },
+      { detected: false, score: 0, reason: 'webgl: renderer normal' },
+    ]
+    const result = score(signals)
+    expect(result.bot).toBe(false)
+    expect(result.confidence).toBe(0)
+    expect(result.reasons).toHaveLength(0)
+    expect(result.botKind).toBe(BotKind.Unknown)
+  })
+
+  it('returns bot for definitive webdriver signal', () => {
+    const signals: Signal[] = [
+      { detected: true, score: 1.0, reason: 'webdriver: true' },
+      { detected: false, score: 0, reason: 'userAgent: ok' },
+    ]
+    const result = score(signals)
+    expect(result.bot).toBe(true)
+    expect(result.confidence).toBeGreaterThan(0.4)
+    expect(result.reasons).toContain('webdriver: true')
+  })
+
+  it('classifies botKind from multiple signals', () => {
+    const signals: Signal[] = [
+      { detected: true, score: 0.9, reason: 'UA: HeadlessChrome', botKind: BotKind.HeadlessChrome },
+      { detected: true, score: 0.8, reason: 'webgl: SwiftShader', botKind: BotKind.HeadlessChrome },
+    ]
+    const result = score(signals)
+    expect(result.bot).toBe(true)
+    expect(result.botKind).toBe(BotKind.HeadlessChrome)
+  })
+
+  it('respects custom threshold', () => {
+    const signals: Signal[] = [
+      { detected: true, score: 0.3, reason: 'weak signal' },
+    ]
+    const lenient = score(signals, { threshold: 0.8 })
+    expect(lenient.bot).toBe(false)
+
+    const strict = score(signals, { threshold: 0.1 })
+    expect(strict.bot).toBe(true)
+  })
+
+  it('includes all signals in result', () => {
+    const signals: Signal[] = [
+      { detected: true, score: 1.0, reason: 'a' },
+      { detected: false, score: 0, reason: 'b' },
+    ]
+    const result = score(signals)
+    expect(result.signals).toHaveLength(2)
+  })
+})
+
+describe('Full Pipeline Integration', () => {
+  it('detects headless Chrome fingerprint', () => {
+    const registry = new DetectorRegistry()
+    registry.registerAll(automationDetectors)
+
+    const data = makeCollectorDict({
+      webDriver: true,
+      userAgent: 'Mozilla/5.0 HeadlessChrome/120.0.0.0',
+      language: [[], []],
+      plugins: 0,
+      webGl: { vendor: 'Google Inc.', renderer: 'Google SwiftShader' },
+    })
+
+    const signals = registry.run(data)
+    const result = score(signals)
+
+    expect(result.bot).toBe(true)
+    expect(result.confidence).toBeGreaterThan(0.5)
+    expect(result.reasons.length).toBeGreaterThan(0)
+  })
+
+  it('passes normal browser fingerprint', () => {
+    const registry = new DetectorRegistry()
+    registry.registerAll(automationDetectors)
+
+    const data = makeCollectorDict()
+    const signals = registry.run(data)
+    const result = score(signals)
+
+    expect(result.bot).toBe(false)
+    expect(result.confidence).toBeLessThan(0.4)
+  })
+})

--- a/packages/bot-detection/src/api.ts
+++ b/packages/bot-detection/src/api.ts
@@ -1,7 +1,15 @@
+import { createDefaultRegistry, score } from './detectors'
+import type { DetectionResult } from './detectors/types'
+import type { ScoringOptions } from './detectors/scoring'
 import { AbstractCollectorDict, CollectorDict, State } from './types'
 import { BotdError } from './utils'
 
-function detect() {}
+const defaultRegistry = createDefaultRegistry()
+
+function detect(data: CollectorDict, options?: ScoringOptions): DetectionResult {
+  const signals = defaultRegistry.run(data)
+  return score(signals, options)
+}
 
 async function collect<T extends AbstractCollectorDict>(collectors: T) {
   const components = {} as CollectorDict<T>
@@ -17,7 +25,7 @@ async function collect<T extends AbstractCollectorDict>(collectors: T) {
           state: State.Success,
         }
       } catch (error) {
-        if (error instanceof BotdError) {
+        if (error instanceof BotdError && error.state !== State.Success) {
           components[collectorKey] = {
             state: error.state,
             error: `${error.name}: ${error.message}`,

--- a/packages/bot-detection/src/detector.ts
+++ b/packages/bot-detection/src/detector.ts
@@ -1,23 +1,20 @@
 import { collect, detect } from './api';
 import { collectors } from './collectors';
-import { CollectorDict, DetectionDict } from './types';
+import type { DetectionResult } from './detectors/types';
+import type { ScoringOptions } from './detectors/scoring';
+import type { CollectorDict, BotDetectorInterface } from './types';
 
-/**
- * Class representing a bot detector.
- *
- * @class
- * @implements {BotDetectorInterface}
- */
-export default class BotDetector {
+export default class BotDetector implements BotDetectorInterface {
   private collections: CollectorDict | undefined = undefined;
-  private detections: DetectionDict | undefined = undefined;
+  private detections: DetectionResult | undefined = undefined;
 
-  public detect() {
+  public detect(options?: ScoringOptions): DetectionResult {
     if (this.collections === undefined) {
       throw new Error('BotDetector.detect must be called after BotDetector.collect');
     }
 
-    this.detections = detect();
+    this.detections = detect(this.collections, options);
+    return this.detections;
   }
 
   public async collect() {

--- a/packages/bot-detection/src/detectors/automation/app_version.ts
+++ b/packages/bot-detection/src/detectors/automation/app_version.ts
@@ -1,0 +1,34 @@
+import type { CollectorDict } from '../../types'
+import { DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const detector: Detector = {
+  name: 'appVersion',
+  category: DetectorCategory.Automation,
+  detect(_data: CollectorDict): Signal {
+    if (typeof navigator === 'undefined') {
+      return { detected: false, score: 0, reason: 'appVersion: no navigator' }
+    }
+
+    const appVersion = navigator.appVersion
+    if (!appVersion || appVersion.length === 0) {
+      return {
+        detected: true,
+        score: 0.5,
+        reason: 'navigator.appVersion is empty or missing',
+      }
+    }
+
+    if (/HeadlessChrome/i.test(appVersion)) {
+      return {
+        detected: true,
+        score: 0.8,
+        reason: 'navigator.appVersion contains "HeadlessChrome"',
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'appVersion: appears normal' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/distinctive_properties.ts
+++ b/packages/bot-detection/src/detectors/automation/distinctive_properties.ts
@@ -1,0 +1,52 @@
+import type { CollectorDict } from '../../types'
+import { BotKind, DetectorCategory, type BotKindValue, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const DISTINCTIVE_PROPS: Array<{
+  object: 'window' | 'navigator' | 'document'
+  property: string
+  botKind: BotKindValue
+}> = [
+  { object: 'window', property: 'callPhantom', botKind: BotKind.PhantomJS },
+  { object: 'window', property: '_phantom', botKind: BotKind.PhantomJS },
+  { object: 'window', property: '__nightmare', botKind: BotKind.Nightmare },
+  { object: 'window', property: '__puppeteer_evaluation_script__', botKind: BotKind.Puppeteer },
+  { object: 'window', property: '__playwright', botKind: BotKind.Playwright },
+  { object: 'window', property: '__pw_manual', botKind: BotKind.Playwright },
+  { object: 'window', property: 'callSelenium', botKind: BotKind.Selenium },
+  { object: 'window', property: '_selenium', botKind: BotKind.Selenium },
+  { object: 'window', property: '__selenium_unwrapped', botKind: BotKind.Selenium },
+  { object: 'window', property: '__webdriver_evaluate', botKind: BotKind.Selenium },
+  { object: 'window', property: '__driver_evaluate', botKind: BotKind.Selenium },
+  { object: 'document', property: '__webdriver_script_fn', botKind: BotKind.Selenium },
+  { object: 'document', property: '__selenium_evaluate', botKind: BotKind.Selenium },
+]
+
+function getGlobalObject(name: 'window' | 'navigator' | 'document'): Record<string, unknown> | undefined {
+  if (name === 'window' && typeof window !== 'undefined') return window as unknown as Record<string, unknown>
+  if (name === 'navigator' && typeof navigator !== 'undefined') return navigator as unknown as Record<string, unknown>
+  if (name === 'document' && typeof document !== 'undefined') return document as unknown as Record<string, unknown>
+  return undefined
+}
+
+const detector: Detector = {
+  name: 'distinctiveProperties',
+  category: DetectorCategory.Automation,
+  detect(_data: CollectorDict): Signal {
+    for (const { object, property, botKind } of DISTINCTIVE_PROPS) {
+      const obj = getGlobalObject(object)
+      if (obj && property in obj) {
+        return {
+          detected: true,
+          score: 1.0,
+          reason: `${object}.${property} exists, indicating ${botKind}`,
+          botKind,
+        }
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'distinctiveProperties: no bot properties found' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/document_element_keys.ts
+++ b/packages/bot-detection/src/detectors/automation/document_element_keys.ts
@@ -1,0 +1,34 @@
+import type { CollectorDict } from '../../types'
+import { BotKind, DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const SUSPICIOUS_PATTERNS = ['selenium', 'webdriver', 'driver']
+
+const detector: Detector = {
+  name: 'documentElementKeys',
+  category: DetectorCategory.Automation,
+  detect(_data: CollectorDict): Signal {
+    if (typeof document === 'undefined' || !document.documentElement) {
+      return { detected: false, score: 0, reason: 'documentElementKeys: no document' }
+    }
+
+    const keys = Object.keys(document.documentElement)
+    for (const key of keys) {
+      const lowerKey = key.toLowerCase()
+      for (const pattern of SUSPICIOUS_PATTERNS) {
+        if (lowerKey.includes(pattern)) {
+          return {
+            detected: true,
+            score: 0.9,
+            reason: `document.documentElement has suspicious key "${key}" containing "${pattern}"`,
+            botKind: BotKind.Selenium,
+          }
+        }
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'documentElementKeys: no suspicious keys' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/error_trace.ts
+++ b/packages/bot-detection/src/detectors/automation/error_trace.ts
@@ -1,0 +1,27 @@
+import type { CollectorDict } from '../../types'
+import { BotKind, DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const detector: Detector = {
+  name: 'errorTrace',
+  category: DetectorCategory.Automation,
+  detect(_data: CollectorDict): Signal {
+    try {
+      throw new Error('trace')
+    } catch (e) {
+      const stack = (e as Error).stack ?? ''
+      if (/PhantomJS/i.test(stack)) {
+        return {
+          detected: true,
+          score: 0.9,
+          reason: 'Error stack trace contains PhantomJS reference',
+          botKind: BotKind.PhantomJS,
+        }
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'errorTrace: no bot patterns found' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/eval_length.ts
+++ b/packages/bot-detection/src/detectors/automation/eval_length.ts
@@ -1,0 +1,27 @@
+import type { CollectorDict } from '../../types'
+import { DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const KNOWN_LENGTHS = new Set([33, 37, 39])
+
+const detector: Detector = {
+  name: 'evalLength',
+  category: DetectorCategory.Automation,
+  detect(_data: CollectorDict): Signal {
+    try {
+      const length = eval.toString().length
+      if (!KNOWN_LENGTHS.has(length)) {
+        return {
+          detected: true,
+          score: 0.6,
+          reason: `eval.toString().length is ${length}, expected one of [33, 37, 39]`,
+        }
+      }
+      return { detected: false, score: 0, reason: 'evalLength: matches known engine' }
+    } catch {
+      return { detected: false, score: 0, reason: 'evalLength: unable to evaluate' }
+    }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/function_bind.ts
+++ b/packages/bot-detection/src/detectors/automation/function_bind.ts
@@ -1,0 +1,22 @@
+import type { CollectorDict } from '../../types'
+import { BotKind, DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const detector: Detector = {
+  name: 'functionBind',
+  category: DetectorCategory.Automation,
+  detect(_data: CollectorDict): Signal {
+    if (typeof Function.prototype.bind !== 'function') {
+      return {
+        detected: true,
+        score: 0.9,
+        reason: 'Function.prototype.bind is missing, indicating PhantomJS',
+        botKind: BotKind.PhantomJS,
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'functionBind: bind exists' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/index.ts
+++ b/packages/bot-detection/src/detectors/automation/index.ts
@@ -1,0 +1,42 @@
+import type { Detector } from '../types'
+import appVersion from './app_version'
+import distinctiveProperties from './distinctive_properties'
+import documentElementKeys from './document_element_keys'
+import errorTrace from './error_trace'
+import evalLength from './eval_length'
+import functionBind from './function_bind'
+import languagesInconsistency from './languages_inconsistency'
+import mimeTypesConsistence from './mime_types_consistence'
+import notificationPermissions from './notification_permissions'
+import pluginsArray from './plugins_array'
+import pluginsInconsistency from './plugins_inconsistency'
+import processDetector from './process_detector'
+import productSub from './product_sub'
+import rtt from './rtt'
+import userAgent from './user_agent'
+import webdriver from './webdriver'
+import webgl from './webgl'
+import windowExternal from './window_external'
+import windowSize from './window_size'
+
+export const automationDetectors: Detector[] = [
+  webdriver,
+  userAgent,
+  evalLength,
+  errorTrace,
+  distinctiveProperties,
+  documentElementKeys,
+  windowSize,
+  rtt,
+  notificationPermissions,
+  pluginsInconsistency,
+  pluginsArray,
+  languagesInconsistency,
+  mimeTypesConsistence,
+  productSub,
+  functionBind,
+  processDetector,
+  appVersion,
+  webgl,
+  windowExternal,
+]

--- a/packages/bot-detection/src/detectors/automation/languages_inconsistency.ts
+++ b/packages/bot-detection/src/detectors/automation/languages_inconsistency.ts
@@ -1,0 +1,30 @@
+import { State } from '../../types'
+import type { CollectorDict } from '../../types'
+import { DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const detector: Detector = {
+  name: 'languagesInconsistency',
+  category: DetectorCategory.Automation,
+  detect(data: CollectorDict): Signal {
+    const component = data.language
+    if (component.state !== State.Success) {
+      return { detected: false, score: 0, reason: 'languagesInconsistency: collector unavailable' }
+    }
+
+    const languageArrays = component.value
+    const hasLanguage = languageArrays.some((arr: string[]) => arr.length > 0)
+
+    if (!hasLanguage) {
+      return {
+        detected: true,
+        score: 0.7,
+        reason: 'navigator.languages is empty, indicating automation environment',
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'languagesInconsistency: languages present' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/mime_types_consistence.ts
+++ b/packages/bot-detection/src/detectors/automation/mime_types_consistence.ts
@@ -1,0 +1,33 @@
+import { State } from '../../types'
+import type { CollectorDict } from '../../types'
+import { DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const detector: Detector = {
+  name: 'mimeTypesConsistence',
+  category: DetectorCategory.Automation,
+  detect(data: CollectorDict): Signal {
+    if (typeof navigator === 'undefined') {
+      return { detected: false, score: 0, reason: 'mimeTypesConsistence: no navigator' }
+    }
+
+    const uaComponent = data.userAgent
+    if (uaComponent.state !== State.Success) {
+      return { detected: false, score: 0, reason: 'mimeTypesConsistence: collector unavailable' }
+    }
+
+    const isChrome = /Chrome/i.test(uaComponent.value) && !/Edge/i.test(uaComponent.value)
+
+    if (isChrome && navigator.mimeTypes && navigator.mimeTypes.length === 0) {
+      return {
+        detected: true,
+        score: 0.6,
+        reason: 'Chrome browser with 0 MIME types, likely headless',
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'mimeTypesConsistence: MIME types present' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/notification_permissions.ts
+++ b/packages/bot-detection/src/detectors/automation/notification_permissions.ts
@@ -1,0 +1,25 @@
+import type { CollectorDict } from '../../types'
+import { DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const detector: Detector = {
+  name: 'notificationPermissions',
+  category: DetectorCategory.Automation,
+  detect(_data: CollectorDict): Signal {
+    if (typeof Notification === 'undefined') {
+      return { detected: false, score: 0, reason: 'notificationPermissions: API unavailable' }
+    }
+
+    if (Notification.permission === 'denied' && !navigator.userAgent) {
+      return {
+        detected: true,
+        score: 0.5,
+        reason: 'Notification permission is denied without user interaction',
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'notificationPermissions: normal state' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/plugins_array.ts
+++ b/packages/bot-detection/src/detectors/automation/plugins_array.ts
@@ -1,0 +1,26 @@
+import type { CollectorDict } from '../../types'
+import { DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const detector: Detector = {
+  name: 'pluginsArray',
+  category: DetectorCategory.Automation,
+  detect(_data: CollectorDict): Signal {
+    if (typeof navigator === 'undefined' || !navigator.plugins) {
+      return { detected: false, score: 0, reason: 'pluginsArray: navigator.plugins unavailable' }
+    }
+
+    const plugins = navigator.plugins
+    if (!(plugins instanceof PluginArray)) {
+      return {
+        detected: true,
+        score: 0.7,
+        reason: 'navigator.plugins is not a genuine PluginArray instance',
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'pluginsArray: structure appears normal' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/plugins_inconsistency.ts
+++ b/packages/bot-detection/src/detectors/automation/plugins_inconsistency.ts
@@ -1,0 +1,34 @@
+import { State } from '../../types'
+import type { CollectorDict } from '../../types'
+import { DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const detector: Detector = {
+  name: 'pluginsInconsistency',
+  category: DetectorCategory.Automation,
+  detect(data: CollectorDict): Signal {
+    const pluginsComponent = data.plugins
+    const uaComponent = data.userAgent
+
+    if (pluginsComponent.state !== State.Success || uaComponent.state !== State.Success) {
+      return { detected: false, score: 0, reason: 'pluginsInconsistency: collector unavailable' }
+    }
+
+    const ua = uaComponent.value
+    const pluginCount = pluginsComponent.value
+    const isChrome = /Chrome/i.test(ua) && !/Edge/i.test(ua)
+    const isAndroid = /Android/i.test(ua)
+
+    if (isChrome && !isAndroid && pluginCount === 0) {
+      return {
+        detected: true,
+        score: 0.7,
+        reason: 'Chrome on desktop with 0 plugins, likely headless',
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'pluginsInconsistency: plugins count normal' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/process_detector.ts
+++ b/packages/bot-detection/src/detectors/automation/process_detector.ts
@@ -1,0 +1,35 @@
+import type { CollectorDict } from '../../types'
+import { BotKind, DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+declare const process: { type?: string; versions?: { electron?: string } } | undefined
+
+const detector: Detector = {
+  name: 'process',
+  category: DetectorCategory.Automation,
+  detect(_data: CollectorDict): Signal {
+    if (typeof process !== 'undefined' && process !== null) {
+      if (process.type === 'renderer') {
+        return {
+          detected: true,
+          score: 0.8,
+          reason: 'process.type is "renderer", indicating Electron environment',
+          botKind: BotKind.Electron,
+        }
+      }
+
+      if (process.versions?.electron) {
+        return {
+          detected: true,
+          score: 0.8,
+          reason: 'process.versions.electron exists, indicating Electron',
+          botKind: BotKind.Electron,
+        }
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'process: no process object in browser' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/product_sub.ts
+++ b/packages/bot-detection/src/detectors/automation/product_sub.ts
@@ -1,0 +1,36 @@
+import { State } from '../../types'
+import type { CollectorDict } from '../../types'
+import { DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const EXPECTED_PRODUCT_SUB = '20030107'
+
+const detector: Detector = {
+  name: 'productSub',
+  category: DetectorCategory.Automation,
+  detect(data: CollectorDict): Signal {
+    const uaComponent = data.userAgent
+    if (uaComponent.state !== State.Success) {
+      return { detected: false, score: 0, reason: 'productSub: collector unavailable' }
+    }
+
+    if (typeof navigator === 'undefined') {
+      return { detected: false, score: 0, reason: 'productSub: no navigator' }
+    }
+
+    const ua = uaComponent.value
+    const isChromeSafariOpera = /Chrome|Safari|Opera/i.test(ua)
+
+    if (isChromeSafariOpera && navigator.productSub !== EXPECTED_PRODUCT_SUB) {
+      return {
+        detected: true,
+        score: 0.6,
+        reason: `productSub is "${navigator.productSub}" but expected "${EXPECTED_PRODUCT_SUB}" for Chrome/Safari/Opera`,
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'productSub: matches expected value' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/rtt.ts
+++ b/packages/bot-detection/src/detectors/automation/rtt.ts
@@ -1,0 +1,42 @@
+import { State } from '../../types'
+import type { CollectorDict } from '../../types'
+import { DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+interface NetworkInformation {
+  rtt?: number
+}
+
+const detector: Detector = {
+  name: 'rtt',
+  category: DetectorCategory.Automation,
+  detect(data: CollectorDict): Signal {
+    if (typeof navigator === 'undefined') {
+      return { detected: false, score: 0, reason: 'rtt: no navigator' }
+    }
+
+    const connection = (navigator as Navigator & { connection?: NetworkInformation }).connection
+    if (!connection || typeof connection.rtt !== 'number') {
+      return { detected: false, score: 0, reason: 'rtt: Network Information API unavailable' }
+    }
+
+    const uaComponent = data.userAgent
+    if (uaComponent.state !== State.Success) {
+      return { detected: false, score: 0, reason: 'rtt: userAgent collector unavailable' }
+    }
+
+    const isAndroid = /Android/i.test(uaComponent.value)
+
+    if (connection.rtt === 0 && !isAndroid) {
+      return {
+        detected: true,
+        score: 0.7,
+        reason: 'navigator.connection.rtt is 0 on non-Android desktop, indicating headless',
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'rtt: value appears normal' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/user_agent.ts
+++ b/packages/bot-detection/src/detectors/automation/user_agent.ts
@@ -1,0 +1,43 @@
+import { State } from '../../types'
+import type { CollectorDict } from '../../types'
+import { BotKind, DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const BOT_UA_PATTERNS: Array<{ pattern: RegExp; botKind: string }> = [
+  { pattern: /HeadlessChrome/i, botKind: BotKind.HeadlessChrome },
+  { pattern: /PhantomJS/i, botKind: BotKind.PhantomJS },
+  { pattern: /Nightmare/i, botKind: BotKind.Nightmare },
+  { pattern: /SlimerJS/i, botKind: BotKind.SlimerJS },
+  { pattern: /Sequentum/i, botKind: BotKind.Sequentum },
+  { pattern: /CefSharp/i, botKind: BotKind.CefSharp },
+  { pattern: /Rhino/i, botKind: BotKind.Rhino },
+  { pattern: /CouchJS/i, botKind: BotKind.CouchJS },
+  { pattern: /Electron/i, botKind: BotKind.Electron },
+]
+
+const detector: Detector = {
+  name: 'userAgent',
+  category: DetectorCategory.Automation,
+  detect(data: CollectorDict): Signal {
+    const component = data.userAgent
+    if (component.state !== State.Success) {
+      return { detected: false, score: 0, reason: 'userAgent: collector unavailable' }
+    }
+
+    const ua = component.value
+    for (const { pattern, botKind } of BOT_UA_PATTERNS) {
+      if (pattern.test(ua)) {
+        return {
+          detected: true,
+          score: 0.9,
+          reason: `User agent contains "${pattern.source}" indicating ${botKind}`,
+          botKind: botKind as Signal['botKind'],
+        }
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'userAgent: no bot patterns found' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/webdriver.ts
+++ b/packages/bot-detection/src/detectors/automation/webdriver.ts
@@ -1,0 +1,28 @@
+import { State } from '../../types'
+import type { CollectorDict } from '../../types'
+import { DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const detector: Detector = {
+  name: 'webdriver',
+  category: DetectorCategory.Automation,
+  detect(data: CollectorDict): Signal {
+    const component = data.webDriver
+    if (component.state !== State.Success) {
+      return { detected: false, score: 0, reason: 'webdriver: collector unavailable' }
+    }
+
+    const value = component.value
+    if (value === true) {
+      return {
+        detected: true,
+        score: 1.0,
+        reason: 'navigator.webdriver is true, indicating automation software',
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'webdriver: not detected' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/webgl.ts
+++ b/packages/bot-detection/src/detectors/automation/webgl.ts
@@ -1,0 +1,42 @@
+import { State } from '../../types'
+import type { CollectorDict } from '../../types'
+import { BotKind, DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const HEADLESS_RENDERERS = [
+  'SwiftShader',
+  'Mesa OffScreen',
+  'llvmpipe',
+  'Software Rasterizer',
+]
+
+const detector: Detector = {
+  name: 'webgl',
+  category: DetectorCategory.Automation,
+  detect(data: CollectorDict): Signal {
+    const component = data.webGl
+    if (component.state !== State.Success) {
+      return { detected: false, score: 0, reason: 'webgl: collector unavailable' }
+    }
+
+    const { renderer } = component.value
+    if (typeof renderer !== 'string') {
+      return { detected: false, score: 0, reason: 'webgl: renderer not a string' }
+    }
+
+    for (const pattern of HEADLESS_RENDERERS) {
+      if (renderer.includes(pattern)) {
+        return {
+          detected: true,
+          score: 0.8,
+          reason: `WebGL renderer "${renderer}" contains "${pattern}", indicating virtual/headless GPU`,
+          botKind: BotKind.HeadlessChrome,
+        }
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'webgl: renderer appears normal' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/window_external.ts
+++ b/packages/bot-detection/src/detectors/automation/window_external.ts
@@ -1,0 +1,36 @@
+import type { CollectorDict } from '../../types'
+import { BotKind, DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const detector: Detector = {
+  name: 'windowExternal',
+  category: DetectorCategory.Automation,
+  detect(_data: CollectorDict): Signal {
+    if (typeof window === 'undefined') {
+      return { detected: false, score: 0, reason: 'windowExternal: no window' }
+    }
+
+    const external = (window as Window & { external?: { toString?: () => string } }).external
+    if (!external) {
+      return { detected: false, score: 0, reason: 'windowExternal: not present' }
+    }
+
+    try {
+      const str = external.toString?.()
+      if (str === '[object Sequentum]') {
+        return {
+          detected: true,
+          score: 0.9,
+          reason: 'window.external identifies as Sequentum',
+          botKind: BotKind.Sequentum,
+        }
+      }
+    } catch {
+      // Some environments throw on toString
+    }
+
+    return { detected: false, score: 0, reason: 'windowExternal: appears normal' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/automation/window_size.ts
+++ b/packages/bot-detection/src/detectors/automation/window_size.ts
@@ -1,0 +1,34 @@
+import { State } from '../../types'
+import type { CollectorDict } from '../../types'
+import { DetectorCategory, type Signal } from '../types'
+import type { Detector } from '../types'
+
+const detector: Detector = {
+  name: 'windowSize',
+  category: DetectorCategory.Automation,
+  detect(data: CollectorDict): Signal {
+    const focus = data.documentFocus
+    if (focus.state !== State.Success || !focus.value) {
+      return { detected: false, score: 0, reason: 'windowSize: document not focused, skipping' }
+    }
+
+    if (typeof window === 'undefined') {
+      return { detected: false, score: 0, reason: 'windowSize: no window object' }
+    }
+
+    const outerWidth = window.outerWidth
+    const outerHeight = window.outerHeight
+
+    if (outerWidth === 0 && outerHeight === 0) {
+      return {
+        detected: true,
+        score: 0.8,
+        reason: 'outerWidth and outerHeight are both 0, indicating headless browser',
+      }
+    }
+
+    return { detected: false, score: 0, reason: 'windowSize: dimensions normal' }
+  },
+}
+
+export default detector

--- a/packages/bot-detection/src/detectors/index.ts
+++ b/packages/bot-detection/src/detectors/index.ts
@@ -1,1 +1,20 @@
-export const detectors = {}
+import { automationDetectors } from './automation'
+import { DetectorRegistry } from './registry'
+
+export { DetectorRegistry } from './registry'
+export { score } from './scoring'
+export type { ScoringOptions } from './scoring'
+export { BotKind, DetectorCategory } from './types'
+export type {
+  BotKindValue,
+  Detector,
+  DetectionResult,
+  DetectorCategoryValue,
+  Signal,
+} from './types'
+
+export function createDefaultRegistry(): DetectorRegistry {
+  const registry = new DetectorRegistry()
+  registry.registerAll(automationDetectors)
+  return registry
+}

--- a/packages/bot-detection/src/detectors/registry.ts
+++ b/packages/bot-detection/src/detectors/registry.ts
@@ -1,0 +1,38 @@
+import type { CollectorDict } from '../types'
+import type { Detector, Signal } from './types'
+
+export class DetectorRegistry {
+  private detectors: Detector[] = []
+
+  register(detector: Detector): void {
+    this.detectors.push(detector)
+  }
+
+  registerAll(detectors: Detector[]): void {
+    for (const detector of detectors) {
+      this.register(detector)
+    }
+  }
+
+  run(data: CollectorDict): Signal[] {
+    const signals: Signal[] = []
+
+    for (const detector of this.detectors) {
+      try {
+        signals.push(detector.detect(data))
+      } catch {
+        signals.push({
+          detected: false,
+          score: 0,
+          reason: `${detector.name}: detector threw an error`,
+        })
+      }
+    }
+
+    return signals
+  }
+
+  getDetectors(): readonly Detector[] {
+    return this.detectors
+  }
+}

--- a/packages/bot-detection/src/detectors/scoring.ts
+++ b/packages/bot-detection/src/detectors/scoring.ts
@@ -1,0 +1,98 @@
+import { BotKind, type BotKindValue, type DetectionResult, type Signal } from './types'
+
+const DEFAULT_WEIGHTS: Record<string, number> = {
+  webdriver: 1.0,
+  userAgent: 0.9,
+  evalLength: 0.6,
+  errorTrace: 0.8,
+  distinctiveProperties: 1.0,
+  documentElementKeys: 0.9,
+  windowSize: 0.7,
+  rtt: 0.6,
+  notificationPermissions: 0.4,
+  pluginsInconsistency: 0.7,
+  pluginsArray: 0.6,
+  languagesInconsistency: 0.7,
+  mimeTypesConsistence: 0.5,
+  productSub: 0.5,
+  functionBind: 0.8,
+  process: 0.8,
+  appVersion: 0.7,
+  webgl: 0.8,
+  windowExternal: 0.9,
+}
+
+const DEFAULT_THRESHOLD = 0.4
+
+export interface ScoringOptions {
+  weights?: Record<string, number>
+  threshold?: number
+}
+
+export function score(signals: Signal[], options?: ScoringOptions): DetectionResult {
+  const weights = { ...DEFAULT_WEIGHTS, ...options?.weights }
+  const threshold = options?.threshold ?? DEFAULT_THRESHOLD
+
+  const detectedSignals = signals.filter((s) => s.detected)
+  const reasons = detectedSignals.map((s) => s.reason)
+
+  let totalWeight = 0
+  let weightedScore = 0
+
+  for (const signal of signals) {
+    const weight = weights[signal.reason.split(':')[0]!] ?? 0.5
+    totalWeight += weight
+    weightedScore += signal.score * weight
+  }
+
+  const normalizedScore = totalWeight > 0 ? weightedScore / totalWeight : 0
+
+  const botKind = determineBotKind(detectedSignals)
+  const confidence = computeConfidence(detectedSignals, normalizedScore)
+
+  return {
+    bot: confidence >= threshold,
+    botKind,
+    confidence,
+    reasons,
+    score: normalizedScore,
+    signals,
+  }
+}
+
+function determineBotKind(detectedSignals: Signal[]): BotKindValue {
+  const kindCounts = new Map<BotKindValue, number>()
+
+  for (const signal of detectedSignals) {
+    if (signal.botKind) {
+      kindCounts.set(signal.botKind, (kindCounts.get(signal.botKind) ?? 0) + signal.score)
+    }
+  }
+
+  if (kindCounts.size === 0) {
+    return detectedSignals.length > 0 ? BotKind.Unknown : BotKind.Unknown
+  }
+
+  let bestKind = BotKind.Unknown as BotKindValue
+  let bestScore = 0
+  for (const [kind, score] of kindCounts) {
+    if (score > bestScore) {
+      bestScore = score
+      bestKind = kind
+    }
+  }
+
+  return bestKind
+}
+
+function computeConfidence(detectedSignals: Signal[], normalizedScore: number): number {
+  if (detectedSignals.length === 0) return 0
+
+  const hasDefinitiveSignal = detectedSignals.some((s) => s.score >= 1.0)
+  if (hasDefinitiveSignal) return Math.min(normalizedScore + 0.3, 1.0)
+
+  const hasStrongSignals = detectedSignals.filter((s) => s.score >= 0.7).length >= 2
+  if (hasStrongSignals) return Math.min(normalizedScore + 0.2, 1.0)
+
+  return normalizedScore
+}

--- a/packages/bot-detection/src/detectors/types.ts
+++ b/packages/bot-detection/src/detectors/types.ts
@@ -1,0 +1,51 @@
+import type { CollectorDict } from '../types'
+
+export const BotKind = {
+  HeadlessChrome: 'HeadlessChrome',
+  PhantomJS: 'PhantomJS',
+  Nightmare: 'Nightmare',
+  Selenium: 'Selenium',
+  Electron: 'Electron',
+  NodeJS: 'NodeJS',
+  Rhino: 'Rhino',
+  CouchJS: 'CouchJS',
+  Sequentum: 'Sequentum',
+  SlimerJS: 'SlimerJS',
+  CefSharp: 'CefSharp',
+  Puppeteer: 'Puppeteer',
+  Playwright: 'Playwright',
+  Unknown: 'Unknown',
+} as const
+
+export type BotKindValue = (typeof BotKind)[keyof typeof BotKind]
+
+export const DetectorCategory = {
+  Automation: 'automation',
+  Inconsistency: 'inconsistency',
+  Behavioral: 'behavioral',
+} as const
+
+export type DetectorCategoryValue =
+  (typeof DetectorCategory)[keyof typeof DetectorCategory]
+
+export interface Signal {
+  detected: boolean
+  score: number
+  reason: string
+  botKind?: BotKindValue
+}
+
+export interface Detector {
+  name: string
+  category: DetectorCategoryValue
+  detect(data: CollectorDict): Signal
+}
+
+export interface DetectionResult {
+  bot: boolean
+  botKind: BotKindValue
+  confidence: number
+  reasons: string[]
+  score: number
+  signals: Signal[]
+}

--- a/packages/bot-detection/src/detectors/user_agent.ts
+++ b/packages/bot-detection/src/detectors/user_agent.ts
@@ -1,1 +1,0 @@
-export function detectUserAgent() {}

--- a/packages/bot-detection/src/index.ts
+++ b/packages/bot-detection/src/index.ts
@@ -7,3 +7,13 @@ async function load() {
 }
 
 export { load }
+export { BotDetector }
+export { DetectorRegistry, BotKind, DetectorCategory, score } from './detectors'
+export type {
+  BotKindValue,
+  Detector,
+  DetectionResult,
+  DetectorCategoryValue,
+  Signal,
+} from './detectors'
+export type { ScoringOptions } from './detectors/scoring'

--- a/packages/bot-detection/src/types.ts
+++ b/packages/bot-detection/src/types.ts
@@ -1,5 +1,5 @@
 import { collectors } from './collectors'
-import { detectors } from './detectors'
+import type { DetectionResult } from './detectors/types'
 
 export const State = {
   Success: 'Success',
@@ -16,13 +16,11 @@ export type Component<T> =
       value: T
     }
   | {
-      state: StateValue
+      state: Exclude<StateValue, typeof State.Success>
       error: string
     }
 
 export type DefaultCollectorDict = typeof collectors
-
-export type DefaultDetectorDict = typeof detectors
 
 export type SourceResponse<T> = T extends (...args: any[]) => any ? Awaited<ReturnType<T>> : T
 
@@ -33,16 +31,7 @@ export type CollectorDict<T extends AbstractSourceDict = DefaultCollectorDict> =
   [K in keyof T]: Component<SourceResponse<T[K]>>
 }
 
-export type DetectionDict = any
-
 export interface BotDetectorInterface {
-  /**
-   * Performs bot detection. Must be called after collect()
-   */
-  detect(): any
-
-  /**
-   * Collects data from sources.
-   */
-  collect(): any
+  detect(): DetectionResult
+  collect(): Promise<CollectorDict>
 }


### PR DESCRIPTION
Phase 2.1-2.3 and 2.6 of the bot detection library: adds the Detector
interface, DetectorRegistry, 19 BotD-style automation artifact detectors
(webdriver, userAgent, evalLength, errorTrace, distinctiveProperties,
documentElementKeys, windowSize, rtt, notificationPermissions,
pluginsInconsistency, pluginsArray, languagesInconsistency,
mimeTypesConsistence, productSub, functionBind, process, appVersion,
webgl, windowExternal), a weighted scoring engine with configurable
thresholds, and full integration into the BotDetector class. Includes
38 tests covering individual detectors, registry, scoring, and
end-to-end pipeline.

https://claude.ai/code/session_01HfNGYhXq5gGJRL34mPJvWV