### PR TITLE
Refine public API surface (Phase 5.1)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ Analysis of the following libraries and approaches informed this plan:
 
 ## Current State
 
-Phase 1 complete (CI deferred to Phase 8), Phase 2 complete, Phase 3 complete, Phase 4 complete. 17 collectors working (added behaviorSnapshot collector). Build pipeline (tsup, ESM+CJS+UMD). Test framework (vitest + jsdom). BehaviorTracker class with circular buffer, time-windowed accumulation, start/stop/reset lifecycle. Core detection engine: DetectorRegistry, 19 automation detectors, tool-specific detectors, 6 browser environment detectors, 5 lie detection detectors, 7 fingerprint/consistency detectors, 4 behavioral detectors (mouse movement, keyboard, scroll, interaction timing), weighted scoring engine. 146 tests passing. Good monorepo foundation (Turborepo, pnpm, TypeScript strict, ESLint).
+Phase 1 complete (CI deferred to Phase 8), Phase 2 complete, Phase 3 complete, Phase 4 complete, Phase 5.1 complete. 17 collectors working (added behaviorSnapshot collector). Build pipeline (tsup, ESM+CJS+UMD). Test framework (vitest + jsdom). BehaviorTracker class with circular buffer, time-windowed accumulation, start/stop/reset lifecycle. Core detection engine: DetectorRegistry, 19 automation detectors, tool-specific detectors, 6 browser environment detectors, 5 lie detection detectors, 7 fingerprint/consistency detectors, 4 behavioral detectors (mouse movement, keyboard, scroll, interaction timing), weighted scoring engine. Refined public API: load(), BotDetector class with full lifecycle methods, DetectOptions, createDefaultRegistry for power users, clean type exports. 166 tests passing. Good monorepo foundation (Turborepo, pnpm, TypeScript strict, ESLint).
 
 ---
 
@@ -242,9 +242,9 @@ Phase 1 complete (CI deferred to Phase 8), Phase 2 complete, Phase 3 complete, P
 
 ## Phase 5: API Refinement & Developer Experience
 
-> **Priority: HIGH** — Enterprise adoption depends on great DX.
+> **Priority: HIGH** — Enterprise adoption depends on great DX (1 of 5 tasks complete).
 
-- [ ] **5.1 Refine public API surface**
+- [x] **5.1 Refine public API surface**
   - `load(options?) => Promise<BotDetector>`
   - `detector.detect(options?) => Promise<DetectionResult>`
   - `detector.collect() => Promise<CollectorData>`

--- a/packages/bot-detection/src/__tests__/public-api.test.ts
+++ b/packages/bot-detection/src/__tests__/public-api.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest'
+import {
+  load,
+  BotDetector,
+  DetectorRegistry,
+  BotKind,
+  DetectorCategory,
+  score,
+  createDefaultRegistry,
+  State,
+  BehaviorTracker,
+} from '../index'
+
+describe('public API surface', () => {
+  it('exports load as a function', () => {
+    expect(typeof load).toBe('function')
+  })
+
+  it('exports BotDetector as a class', () => {
+    expect(typeof BotDetector).toBe('function')
+    expect(typeof BotDetector.isBot).toBe('function')
+  })
+
+  it('exports DetectorRegistry as a class', () => {
+    expect(typeof DetectorRegistry).toBe('function')
+  })
+
+  it('exports BotKind enum', () => {
+    expect(BotKind.HeadlessChrome).toBe('HeadlessChrome')
+    expect(BotKind.Puppeteer).toBe('Puppeteer')
+    expect(BotKind.Playwright).toBe('Playwright')
+    expect(BotKind.Selenium).toBe('Selenium')
+    expect(BotKind.Unknown).toBe('Unknown')
+  })
+
+  it('exports DetectorCategory enum', () => {
+    expect(DetectorCategory.Automation).toBe('automation')
+    expect(DetectorCategory.Inconsistency).toBe('inconsistency')
+    expect(DetectorCategory.Behavioral).toBe('behavioral')
+  })
+
+  it('exports score as a function', () => {
+    expect(typeof score).toBe('function')
+  })
+
+  it('exports createDefaultRegistry as a function', () => {
+    expect(typeof createDefaultRegistry).toBe('function')
+  })
+
+  it('exports State enum', () => {
+    expect(State.Success).toBe('Success')
+    expect(State.Undefined).toBe('Undefined')
+    expect(State.NotFunction).toBe('NotFunction')
+    expect(State.Null).toBe('Null')
+  })
+
+  it('exports BehaviorTracker as a class', () => {
+    expect(typeof BehaviorTracker).toBe('function')
+  })
+})
+
+describe('BotDetector.isBot', () => {
+  it('returns true when result.bot is true', () => {
+    const result = {
+      bot: true,
+      botKind: BotKind.Puppeteer,
+      confidence: 0.9,
+      reasons: ['webdriver detected'],
+      score: 0.8,
+      signals: [],
+    }
+    expect(BotDetector.isBot(result)).toBe(true)
+  })
+
+  it('returns false when result.bot is false', () => {
+    const result = {
+      bot: false,
+      botKind: BotKind.Unknown,
+      confidence: 0.1,
+      reasons: [],
+      score: 0.1,
+      signals: [],
+    }
+    expect(BotDetector.isBot(result)).toBe(false)
+  })
+})
+
+describe('BotDetector instance', () => {
+  it('has all public methods', () => {
+    const detector = new BotDetector()
+    expect(typeof detector.detect).toBe('function')
+    expect(typeof detector.collect).toBe('function')
+    expect(typeof detector.getBehaviorScore).toBe('function')
+    expect(typeof detector.startBehaviorTracking).toBe('function')
+    expect(typeof detector.stopBehaviorTracking).toBe('function')
+    expect(typeof detector.getFingerprint).toBe('function')
+    expect(typeof detector.destroy).toBe('function')
+    expect(typeof detector.getCollections).toBe('function')
+    expect(typeof detector.getDetections).toBe('function')
+  })
+
+  it('returns empty fingerprint before collect', () => {
+    const detector = new BotDetector()
+    expect(detector.getFingerprint()).toBe('')
+  })
+
+  it('returns undefined collections and detections before use', () => {
+    const detector = new BotDetector()
+    expect(detector.getCollections()).toBeUndefined()
+    expect(detector.getDetections()).toBeUndefined()
+  })
+
+  it('returns default behavior score when no tracker started', () => {
+    const detector = new BotDetector()
+    const result = detector.getBehaviorScore()
+    expect(result).toEqual({
+      bot: false,
+      score: 0,
+      reasons: [],
+      duration: 0,
+    })
+  })
+
+  it('cleans up on destroy', () => {
+    const detector = new BotDetector()
+    detector.destroy()
+    expect(detector.getCollections()).toBeUndefined()
+    expect(detector.getDetections()).toBeUndefined()
+  })
+})
+
+describe('createDefaultRegistry', () => {
+  it('returns a registry with detectors', () => {
+    const registry = createDefaultRegistry()
+    const detectors = registry.getDetectors()
+    expect(detectors.length).toBeGreaterThan(0)
+  })
+
+  it('includes detectors from all categories', () => {
+    const registry = createDefaultRegistry()
+    const detectors = registry.getDetectors()
+    const categories = new Set(detectors.map((d) => d.category))
+    expect(categories.has('automation')).toBe(true)
+    expect(categories.has('inconsistency')).toBe(true)
+    expect(categories.has('behavioral')).toBe(true)
+  })
+})
+
+describe('score function', () => {
+  it('returns a valid DetectionResult for empty signals', () => {
+    const result = score([])
+    expect(result).toEqual({
+      bot: false,
+      botKind: BotKind.Unknown,
+      confidence: 0,
+      reasons: [],
+      score: 0,
+      signals: [],
+    })
+  })
+
+  it('respects custom threshold', () => {
+    const signals = [
+      { detected: true, score: 0.3, reason: 'test: mild signal' },
+    ]
+    const low = score(signals, { threshold: 0.1 })
+    const high = score(signals, { threshold: 0.9 })
+    expect(low.bot).toBe(true)
+    expect(high.bot).toBe(false)
+  })
+})

--- a/packages/bot-detection/src/detector.ts
+++ b/packages/bot-detection/src/detector.ts
@@ -4,18 +4,18 @@ import type { BehaviorTrackerOptions, BehaviorSnapshot } from './behavioral/trac
 import { setBehaviorSnapshot } from './collectors/behavior_snapshot'
 import { collectors } from './collectors'
 import type { DetectionResult } from './detectors/types'
-import type { ScoringOptions } from './detectors/scoring'
 import type {
   BehaviorResult,
   BotDetectorInterface,
   CollectorDict,
+  DetectOptions,
   LoadOptions,
 } from './types'
 
-export default class BotDetector implements BotDetectorInterface {
+export class BotDetector implements BotDetectorInterface {
   private collections: CollectorDict | undefined = undefined
   private detections: DetectionResult | undefined = undefined
-  private scoringOptions: ScoringOptions | undefined
+  private scoringOptions: DetectOptions | undefined
   private behaviorTracker: BehaviorTracker | undefined
   private behaviorOptions: BehaviorTrackerOptions | undefined
   private monitoring: boolean
@@ -26,7 +26,7 @@ export default class BotDetector implements BotDetectorInterface {
     this.monitoring = options?.monitoring ?? false
   }
 
-  public async detect(options?: ScoringOptions): Promise<DetectionResult> {
+  public async detect(options?: DetectOptions): Promise<DetectionResult> {
     if (this.collections === undefined) {
       await this.collect()
     }
@@ -42,7 +42,7 @@ export default class BotDetector implements BotDetectorInterface {
     return this.detections
   }
 
-  public async collect() {
+  public async collect(): Promise<CollectorDict> {
     this.collections = await collect(collectors)
     return this.collections
   }
@@ -97,11 +97,11 @@ export default class BotDetector implements BotDetectorInterface {
     this.detections = undefined
   }
 
-  public getCollections() {
+  public getCollections(): CollectorDict | undefined {
     return this.collections
   }
 
-  public getDetections() {
+  public getDetections(): DetectionResult | undefined {
     return this.detections
   }
 

--- a/packages/bot-detection/src/index.ts
+++ b/packages/bot-detection/src/index.ts
@@ -1,7 +1,7 @@
-import BotDetector from './detector'
+import { BotDetector } from './detector'
 import type { LoadOptions } from './types'
 
-async function load(options?: LoadOptions) {
+async function load(options?: LoadOptions): Promise<BotDetector> {
   const detector = new BotDetector(options)
   await detector.collect()
 
@@ -14,7 +14,14 @@ async function load(options?: LoadOptions) {
 
 export { load }
 export { BotDetector }
-export { DetectorRegistry, BotKind, DetectorCategory, score } from './detectors'
+
+export {
+  DetectorRegistry,
+  BotKind,
+  DetectorCategory,
+  score,
+  createDefaultRegistry,
+} from './detectors'
 export type {
   BotKindValue,
   Detector,
@@ -22,8 +29,19 @@ export type {
   DetectorCategoryValue,
   Signal,
 } from './detectors'
+
 export type { ScoringOptions } from './detectors/scoring'
-export type { LoadOptions, BehaviorResult } from './types'
+
+export type {
+  LoadOptions,
+  DetectOptions,
+  BehaviorResult,
+  CollectorDict,
+  Component,
+  StateValue,
+} from './types'
+export { State } from './types'
+
 export { BehaviorTracker } from './behavioral'
 export type {
   BehaviorSnapshot,
@@ -33,4 +51,3 @@ export type {
   KeyEvent_,
   ScrollEvent_,
 } from './behavioral'
-export { setBehaviorSnapshot } from './collectors/behavior_snapshot'

--- a/packages/bot-detection/src/types.ts
+++ b/packages/bot-detection/src/types.ts
@@ -33,6 +33,10 @@ export type CollectorDict<T extends AbstractSourceDict = DefaultCollectorDict> =
   [K in keyof T]: Component<SourceResponse<T[K]>>
 }
 
+export interface DetectOptions extends ScoringOptions {
+  debug?: boolean
+}
+
 export interface LoadOptions {
   scoring?: ScoringOptions
   behavior?: BehaviorTrackerOptions
@@ -47,11 +51,13 @@ export interface BehaviorResult {
 }
 
 export interface BotDetectorInterface {
-  detect(options?: ScoringOptions): Promise<DetectionResult>
+  detect(options?: DetectOptions): Promise<DetectionResult>
   collect(): Promise<CollectorDict>
   getBehaviorScore(): BehaviorResult
   startBehaviorTracking(): void
   stopBehaviorTracking(): void
   getFingerprint(): string
   destroy(): void
+  getCollections(): CollectorDict | undefined
+  getDetections(): DetectionResult | undefined
 }


### PR DESCRIPTION
- Add DetectOptions type extending ScoringOptions with debug flag
- Add getCollections/getDetections to BotDetectorInterface
- Change BotDetector from default to named export for consistency
- Add explicit return type annotations on all public methods
- Export createDefaultRegistry, CollectorDict, Component, State, DetectOptions
- Remove internal setBehaviorSnapshot from public exports
- Add comprehensive public API surface tests (20 new tests)

https://claude.ai/code/session_01BkezCigyreVbuD2gQmm86q