### PR TITLE
Add plugin system with defineDetector, defineCollector, definePlugin helpers and built-in plugins

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ Analysis of the following libraries and approaches informed this plan:
 
 ## Current State
 
-Phase 1 complete (CI deferred to Phase 8), Phase 2 complete, Phase 3 complete, Phase 4 complete, Phase 5.1 complete, Phase 5.2 complete, Phase 5.3 complete. 17 collectors working (added behaviorSnapshot collector). Build pipeline (tsup, ESM+CJS+UMD). Test framework (vitest + jsdom). BehaviorTracker class with circular buffer, time-windowed accumulation, start/stop/reset lifecycle. Core detection engine: DetectorRegistry, 19 automation detectors, tool-specific detectors, 6 browser environment detectors, 5 lie detection detectors, 7 fingerprint/consistency detectors, 4 behavioral detectors (mouse movement, keyboard, scroll, interaction timing), weighted scoring engine. Refined public API: load(), BotDetector class with full lifecycle methods, DetectOptions, createDefaultRegistry for power users, clean type exports. Configuration system with detector/collector enable/disable, privacy mode (disable fingerprinting by technique), performance mode (skip expensive detectors), and combined preset resolution. Debug/telemetry mode with DebugLogger: per-operation timing for collectors/detectors/scoring, structured log entries, DebugReport export via getDebugReport() and exportDebugJSON(). 211 tests passing. Good monorepo foundation (Turborepo, pnpm, TypeScript strict, ESLint).
+Phase 1 complete (CI deferred to Phase 8), Phase 2 complete, Phase 3 complete, Phase 4 complete, Phase 5.1 complete, Phase 5.2 complete, Phase 5.3 complete, Phase 5.4 complete. 17 collectors working (added behaviorSnapshot collector). Build pipeline (tsup, ESM+CJS+UMD). Test framework (vitest + jsdom). BehaviorTracker class with circular buffer, time-windowed accumulation, start/stop/reset lifecycle. Core detection engine: DetectorRegistry, 19 automation detectors, tool-specific detectors, 6 browser environment detectors, 5 lie detection detectors, 7 fingerprint/consistency detectors, 4 behavioral detectors (mouse movement, keyboard, scroll, interaction timing), weighted scoring engine. Refined public API: load(), BotDetector class with full lifecycle methods, DetectOptions, createDefaultRegistry for power users, clean type exports. Configuration system with detector/collector enable/disable, privacy mode (disable fingerprinting by technique), performance mode (skip expensive detectors), and combined preset resolution. Debug/telemetry mode with DebugLogger: per-operation timing for collectors/detectors/scoring, structured log entries, DebugReport export via getDebugReport() and exportDebugJSON(). Plugin system: defineDetector(), defineCollector(), definePlugin() helpers, BotDetector.use(plugin) registration, built-in honeypot and cookieless browsing plugins. 228 tests passing. Good monorepo foundation (Turborepo, pnpm, TypeScript strict, ESLint).
 
 ---
 
@@ -242,7 +242,7 @@ Phase 1 complete (CI deferred to Phase 8), Phase 2 complete, Phase 3 complete, P
 
 ## Phase 5: API Refinement & Developer Experience
 
-> **Priority: HIGH** — Enterprise adoption depends on great DX (3 of 5 tasks complete).
+> **Priority: HIGH** — Enterprise adoption depends on great DX (4 of 5 tasks complete).
 
 - [x] **5.1 Refine public API surface**
   - `load(options?) => Promise<BotDetector>`
@@ -275,7 +275,7 @@ Phase 1 complete (CI deferred to Phase 8), Phase 2 complete, Phase 3 complete, P
   - Performance timing for each detection phase (totalDuration in report)
   - [ ] Visual debug panel option (injectable DOM overlay) — deferred to Phase 7
 
-- [ ] **5.4 Implement plugin system**
+- [x] **5.4 Implement plugin system**
   - `defineDetector()` helper for custom detectors
   - `defineCollector()` helper for custom collectors
   - Plugin interface: `{ name, collectors?, detectors?, init? }`

--- a/packages/bot-detection/src/__tests__/plugin.test.ts
+++ b/packages/bot-detection/src/__tests__/plugin.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  BotDetector,
+  defineDetector,
+  defineCollector,
+  definePlugin,
+  DetectorCategory,
+  honeypotPlugin,
+  cookielessPlugin,
+} from '../index'
+import type { Plugin, CollectorFn } from '../plugin'
+import type { CollectorDict, Component } from '../types'
+import { State } from '../types'
+
+describe('defineDetector', () => {
+  it('returns a valid Detector object', () => {
+    const detector = defineDetector({
+      name: 'testDetector',
+      category: DetectorCategory.Automation,
+      detect: () => ({ detected: false, score: 0, reason: 'test' }),
+    })
+    expect(detector.name).toBe('testDetector')
+    expect(detector.category).toBe('automation')
+    expect(typeof detector.detect).toBe('function')
+  })
+})
+
+describe('defineCollector', () => {
+  it('returns a record with the named collector function', () => {
+    const result = defineCollector('myCollector', () => 42)
+    expect(typeof result.myCollector).toBe('function')
+    expect(result.myCollector()).toBe(42)
+  })
+})
+
+describe('definePlugin', () => {
+  it('returns a Plugin with all fields', () => {
+    const plugin = definePlugin({
+      name: 'test',
+      collectors: { foo: () => 'bar' },
+      detectors: [
+        defineDetector({
+          name: 'd1',
+          category: DetectorCategory.Automation,
+          detect: () => ({ detected: false, score: 0, reason: 'noop' }),
+        }),
+      ],
+      init: () => {},
+    })
+    expect(plugin.name).toBe('test')
+    expect(plugin.collectors).toBeDefined()
+    expect(plugin.detectors).toHaveLength(1)
+    expect(typeof plugin.init).toBe('function')
+  })
+})
+
+describe('BotDetector.use(plugin)', () => {
+  it('calls plugin init', async () => {
+    const initFn = vi.fn()
+    const plugin = definePlugin({ name: 'initTest', init: initFn })
+    const detector = new BotDetector()
+    await detector.use(plugin)
+    expect(initFn).toHaveBeenCalledOnce()
+  })
+
+  it('registers plugin detectors that run during detect()', async () => {
+    const plugin = definePlugin({
+      name: 'customDetect',
+      detectors: [
+        defineDetector({
+          name: 'alwaysDetects',
+          category: DetectorCategory.Automation,
+          detect: () => ({
+            detected: true,
+            score: 1.0,
+            reason: 'alwaysDetects: always fires',
+          }),
+        }),
+      ],
+    })
+
+    const detector = new BotDetector()
+    await detector.use(plugin)
+    const result = await detector.detect()
+    const reasons = result.reasons
+    expect(reasons.some((r: string) => r.includes('alwaysDetects'))).toBe(true)
+  })
+
+  it('registers plugin collectors that run during collect()', async () => {
+    const plugin = definePlugin({
+      name: 'customCollect',
+      collectors: {
+        customValue: () => 'hello from plugin',
+      },
+    })
+
+    const detector = new BotDetector()
+    await detector.use(plugin)
+    const data = await detector.collect()
+    const component = (data as Record<string, Component<string>>).customValue
+    expect(component).toBeDefined()
+    expect(component.state).toBe(State.Success)
+    if (component.state === State.Success) {
+      expect(component.value).toBe('hello from plugin')
+    }
+  })
+
+  it('supports async init', async () => {
+    let initialized = false
+    const plugin = definePlugin({
+      name: 'asyncInit',
+      init: async () => {
+        initialized = true
+      },
+    })
+
+    const detector = new BotDetector()
+    await detector.use(plugin)
+    expect(initialized).toBe(true)
+  })
+
+  it('supports multiple plugins', async () => {
+    const p1 = definePlugin({
+      name: 'p1',
+      collectors: { val1: () => 1 },
+    })
+    const p2 = definePlugin({
+      name: 'p2',
+      collectors: { val2: () => 2 },
+    })
+
+    const detector = new BotDetector()
+    await detector.use(p1)
+    await detector.use(p2)
+    const data = await detector.collect()
+    expect((data as Record<string, Component<number>>).val1?.state).toBe(State.Success)
+    expect((data as Record<string, Component<number>>).val2?.state).toBe(State.Success)
+  })
+})
+
+describe('built-in plugins', () => {
+  describe('honeypotPlugin', () => {
+    it('has correct name and structure', () => {
+      expect(honeypotPlugin.name).toBe('honeypot')
+      expect(honeypotPlugin.collectors).toBeDefined()
+      expect(honeypotPlugin.collectors!.honeypot).toBeDefined()
+      expect(honeypotPlugin.detectors).toHaveLength(1)
+      expect(honeypotPlugin.detectors![0]!.name).toBe('honeypotFilled')
+    })
+
+    it('collector returns triggered: false when no honeypot fields filled', () => {
+      const result = honeypotPlugin.collectors!.honeypot!()
+      expect(result).toEqual({ triggered: false, fields: [] })
+    })
+
+    it('detector returns not detected when no data', () => {
+      const detector = honeypotPlugin.detectors![0]!
+      const signal = detector.detect({} as CollectorDict)
+      expect(signal.detected).toBe(false)
+    })
+  })
+
+  describe('cookielessPlugin', () => {
+    it('has correct name and structure', () => {
+      expect(cookielessPlugin.name).toBe('cookieless')
+      expect(cookielessPlugin.collectors).toBeDefined()
+      expect(cookielessPlugin.collectors!.cookieless).toBeDefined()
+      expect(cookielessPlugin.detectors).toHaveLength(1)
+      expect(cookielessPlugin.detectors![0]!.name).toBe('cookielessBrowsing')
+    })
+
+    it('collector checks storage availability', () => {
+      const result = cookielessPlugin.collectors!.cookieless!() as {
+        cookiesEnabled: boolean
+        localStorageAvailable: boolean
+        sessionStorageAvailable: boolean
+      }
+      expect(typeof result.cookiesEnabled).toBe('boolean')
+      expect(typeof result.localStorageAvailable).toBe('boolean')
+      expect(typeof result.sessionStorageAvailable).toBe('boolean')
+    })
+
+    it('detector returns not detected when no data', () => {
+      const detector = cookielessPlugin.detectors![0]!
+      const signal = detector.detect({} as CollectorDict)
+      expect(signal.detected).toBe(false)
+    })
+
+    it('detector detects when all storage blocked', () => {
+      const detector = cookielessPlugin.detectors![0]!
+      const data = {
+        cookieless: {
+          state: State.Success,
+          value: {
+            cookiesEnabled: false,
+            localStorageAvailable: false,
+            sessionStorageAvailable: false,
+          },
+        },
+      } as unknown as CollectorDict
+      const signal = detector.detect(data)
+      expect(signal.detected).toBe(true)
+      expect(signal.score).toBe(0.6)
+    })
+
+    it('detector detects when cookies disabled', () => {
+      const detector = cookielessPlugin.detectors![0]!
+      const data = {
+        cookieless: {
+          state: State.Success,
+          value: {
+            cookiesEnabled: false,
+            localStorageAvailable: true,
+            sessionStorageAvailable: true,
+          },
+        },
+      } as unknown as CollectorDict
+      const signal = detector.detect(data)
+      expect(signal.detected).toBe(true)
+      expect(signal.score).toBe(0.3)
+    })
+
+    it('detector returns not detected when storage available', () => {
+      const detector = cookielessPlugin.detectors![0]!
+      const data = {
+        cookieless: {
+          state: State.Success,
+          value: {
+            cookiesEnabled: true,
+            localStorageAvailable: true,
+            sessionStorageAvailable: true,
+          },
+        },
+      } as unknown as CollectorDict
+      const signal = detector.detect(data)
+      expect(signal.detected).toBe(false)
+    })
+  })
+})

--- a/packages/bot-detection/src/detector.ts
+++ b/packages/bot-detection/src/detector.ts
@@ -1,11 +1,14 @@
-import { collect, detect } from './api'
+import { collect } from './api'
 import { BehaviorTracker } from './behavioral'
 import type { BehaviorTrackerOptions, BehaviorSnapshot } from './behavioral/tracker'
 import { setBehaviorSnapshot } from './collectors/behavior_snapshot'
 import { collectors } from './collectors'
 import { resolveFilters, filterByName, type BotDetectionConfig, type ResolvedFilters } from './config'
 import { DebugLogger, type DebugReport } from './debug'
+import { createDefaultRegistry, score } from './detectors'
+import { DetectorRegistry } from './detectors/registry'
 import type { DetectionResult } from './detectors/types'
+import type { Plugin, CollectorFn } from './plugin'
 import type {
   BehaviorResult,
   BotDetectorInterface,
@@ -24,6 +27,9 @@ export class BotDetector implements BotDetectorInterface {
   private filters: ResolvedFilters
   private debugLogger: DebugLogger | undefined
   private lastDebugReport: DebugReport | undefined
+  private registry: DetectorRegistry
+  private pluginCollectors: Record<string, CollectorFn> = {}
+  private plugins: Plugin[] = []
 
   constructor(options?: BotDetectionConfig) {
     this.config = options ?? {}
@@ -31,6 +37,7 @@ export class BotDetector implements BotDetectorInterface {
     this.behaviorOptions = options?.behavior
     this.monitoring = options?.monitoring ?? false
     this.filters = resolveFilters(this.config)
+    this.registry = createDefaultRegistry()
     if (this.config.debug) {
       this.debugLogger = new DebugLogger()
     }
@@ -70,7 +77,8 @@ export class BotDetector implements BotDetectorInterface {
     }
 
     const opts = options ?? this.scoringOptions
-    this.detections = detect(this.collections!, opts, detectorFilter, logger)
+    const signals = this.registry.run(this.collections!, detectorFilter, logger)
+    this.detections = score(signals, opts, logger)
 
     if (logger) {
       this.lastDebugReport = logger.buildReport({
@@ -97,9 +105,26 @@ export class BotDetector implements BotDetectorInterface {
     return this.collections
   }
 
+  public async use(plugin: Plugin): Promise<void> {
+    this.plugins.push(plugin)
+
+    if (plugin.init) {
+      await plugin.init()
+    }
+
+    if (plugin.detectors) {
+      this.registry.registerAll(plugin.detectors)
+    }
+
+    if (plugin.collectors) {
+      Object.assign(this.pluginCollectors, plugin.collectors)
+    }
+  }
+
   private getFilteredCollectors() {
+    const merged = { ...collectors, ...this.pluginCollectors }
     return filterByName(
-      collectors,
+      merged,
       this.config.collectors,
       this.filters.disabledCollectors,
     )

--- a/packages/bot-detection/src/index.ts
+++ b/packages/bot-detection/src/index.ts
@@ -67,3 +67,8 @@ export type {
   KeyEvent_,
   ScrollEvent_,
 } from './behavioral'
+
+export { defineDetector, defineCollector, definePlugin } from './plugin'
+export type { Plugin, CollectorFn } from './plugin'
+
+export { honeypotPlugin, cookielessPlugin } from './plugins'

--- a/packages/bot-detection/src/plugin.ts
+++ b/packages/bot-detection/src/plugin.ts
@@ -1,0 +1,30 @@
+import type { Detector, DetectorCategoryValue, Signal } from './detectors/types'
+import type { CollectorDict } from './types'
+
+export type CollectorFn = () => unknown | Promise<unknown>
+
+export interface Plugin {
+  name: string
+  collectors?: Record<string, CollectorFn>
+  detectors?: Detector[]
+  init?: () => void | Promise<void>
+}
+
+export function defineDetector(config: {
+  name: string
+  category: DetectorCategoryValue
+  detect: (data: CollectorDict) => Signal
+}): Detector {
+  return config
+}
+
+export function defineCollector<T>(
+  name: string,
+  fn: () => T | Promise<T>,
+): Record<string, () => T | Promise<T>> {
+  return { [name]: fn }
+}
+
+export function definePlugin(config: Plugin): Plugin {
+  return config
+}

--- a/packages/bot-detection/src/plugins/cookieless.ts
+++ b/packages/bot-detection/src/plugins/cookieless.ts
@@ -1,0 +1,90 @@
+import { definePlugin } from '../plugin'
+import { DetectorCategory } from '../detectors/types'
+import type { CollectorDict, Component } from '../types'
+import { State } from '../types'
+
+interface CookielessState {
+  cookiesEnabled: boolean
+  localStorageAvailable: boolean
+  sessionStorageAvailable: boolean
+}
+
+function getCookielessState(): CookielessState {
+  const cookiesEnabled =
+    typeof navigator !== 'undefined' ? navigator.cookieEnabled : false
+
+  let localStorageAvailable = false
+  try {
+    if (typeof localStorage !== 'undefined') {
+      const key = '__botd_ls_test__'
+      localStorage.setItem(key, '1')
+      localStorage.removeItem(key)
+      localStorageAvailable = true
+    }
+  } catch {
+    // blocked or unavailable
+  }
+
+  let sessionStorageAvailable = false
+  try {
+    if (typeof sessionStorage !== 'undefined') {
+      const key = '__botd_ss_test__'
+      sessionStorage.setItem(key, '1')
+      sessionStorage.removeItem(key)
+      sessionStorageAvailable = true
+    }
+  } catch {
+    // blocked or unavailable
+  }
+
+  return { cookiesEnabled, localStorageAvailable, sessionStorageAvailable }
+}
+
+export const cookielessPlugin = definePlugin({
+  name: 'cookieless',
+  collectors: {
+    cookieless: getCookielessState,
+  },
+  detectors: [
+    {
+      name: 'cookielessBrowsing',
+      category: DetectorCategory.Inconsistency,
+      detect(data: CollectorDict) {
+        const component = (data as Record<string, Component<CookielessState>>).cookieless
+        if (!component || component.state !== State.Success) {
+          return { detected: false, score: 0, reason: 'cookielessBrowsing: no storage data available' }
+        }
+
+        const { cookiesEnabled, localStorageAvailable, sessionStorageAvailable } = component.value
+        const blockedCount = [cookiesEnabled, localStorageAvailable, sessionStorageAvailable]
+          .filter((v) => !v).length
+
+        if (blockedCount === 3) {
+          return {
+            detected: true,
+            score: 0.6,
+            reason: 'cookielessBrowsing: all storage mechanisms blocked (cookies, localStorage, sessionStorage)',
+          }
+        }
+
+        if (blockedCount === 2) {
+          return {
+            detected: true,
+            score: 0.4,
+            reason: 'cookielessBrowsing: multiple storage mechanisms blocked',
+          }
+        }
+
+        if (!cookiesEnabled) {
+          return {
+            detected: true,
+            score: 0.3,
+            reason: 'cookielessBrowsing: cookies disabled',
+          }
+        }
+
+        return { detected: false, score: 0, reason: 'cookielessBrowsing: storage mechanisms available' }
+      },
+    },
+  ],
+})

--- a/packages/bot-detection/src/plugins/honeypot.ts
+++ b/packages/bot-detection/src/plugins/honeypot.ts
@@ -1,0 +1,70 @@
+import { definePlugin } from '../plugin'
+import { DetectorCategory } from '../detectors/types'
+import type { CollectorDict, Component } from '../types'
+import { State } from '../types'
+
+function getHoneypotState() {
+  if (typeof document === 'undefined') return { triggered: false, fields: [] as string[] }
+
+  const fields: string[] = []
+  const honeypotSelectors = [
+    'input[tabindex="-1"][autocomplete="off"]',
+    'input[style*="display:none"]',
+    'input[style*="display: none"]',
+    'input[style*="visibility:hidden"]',
+    'input[style*="visibility: hidden"]',
+    'input[style*="position:absolute"][style*="left:-"]',
+    '.honeypot input',
+    'input[name="website"]',
+    'input[name="url"]',
+    'input[name="fax"]',
+    'input[name="phone2"]',
+    'input[name="address2"]',
+  ]
+
+  for (const selector of honeypotSelectors) {
+    try {
+      const els = document.querySelectorAll<HTMLInputElement>(selector)
+      for (let i = 0; i < els.length; i++) {
+        const el = els[i]!
+        if (el.value && el.value.length > 0) {
+          fields.push(el.name || el.id || selector)
+        }
+      }
+    } catch {
+      // selector may be invalid in some environments
+    }
+  }
+
+  return { triggered: fields.length > 0, fields }
+}
+
+export const honeypotPlugin = definePlugin({
+  name: 'honeypot',
+  collectors: {
+    honeypot: getHoneypotState,
+  },
+  detectors: [
+    {
+      name: 'honeypotFilled',
+      category: DetectorCategory.Automation,
+      detect(data: CollectorDict) {
+        const component = (data as Record<string, Component<{ triggered: boolean; fields: string[] }>>).honeypot
+        if (!component || component.state !== State.Success) {
+          return { detected: false, score: 0, reason: 'honeypotFilled: no honeypot data available' }
+        }
+
+        const { triggered, fields } = component.value
+        if (triggered) {
+          return {
+            detected: true,
+            score: 0.9,
+            reason: `honeypotFilled: hidden fields filled (${fields.join(', ')})`,
+          }
+        }
+
+        return { detected: false, score: 0, reason: 'honeypotFilled: no hidden fields filled' }
+      },
+    },
+  ],
+})

--- a/packages/bot-detection/src/plugins/index.ts
+++ b/packages/bot-detection/src/plugins/index.ts
@@ -1,0 +1,2 @@
+export { honeypotPlugin } from './honeypot'
+export { cookielessPlugin } from './cookieless'

--- a/packages/bot-detection/src/types.ts
+++ b/packages/bot-detection/src/types.ts
@@ -1,6 +1,7 @@
 import { collectors } from './collectors'
 import type { DetectionResult } from './detectors/types'
 import type { ScoringOptions } from './detectors/scoring'
+import type { Plugin } from './plugin'
 
 export const State = {
   Success: 'Success',
@@ -46,7 +47,7 @@ export interface BehaviorResult {
 export interface BotDetectorInterface {
   detect(options?: DetectOptions): Promise<DetectionResult>
   collect(): Promise<CollectorDict>
-  use(plugin: import('./plugin').Plugin): Promise<void>
+  use(plugin: Plugin): Promise<void>
   getBehaviorScore(): BehaviorResult
   startBehaviorTracking(): void
   stopBehaviorTracking(): void

--- a/packages/bot-detection/src/types.ts
+++ b/packages/bot-detection/src/types.ts
@@ -46,6 +46,7 @@ export interface BehaviorResult {
 export interface BotDetectorInterface {
   detect(options?: DetectOptions): Promise<DetectionResult>
   collect(): Promise<CollectorDict>
+  use(plugin: import('./plugin').Plugin): Promise<void>
   getBehaviorScore(): BehaviorResult
   startBehaviorTracking(): void
   stopBehaviorTracking(): void


### PR DESCRIPTION
Implements Phase 5.4: extensible plugin architecture for custom detectors and collectors.
BotDetector.use(plugin) registers plugin collectors/detectors at runtime.
Includes honeypot detection and cookie-less browsing detection as built-in plugins.
228 tests passing (17 new plugin tests).

https://claude.ai/code/session_015CtdEABE3oujF2GcuAD3n5